### PR TITLE
Fix bug that allows whitespace before/after filename

### DIFF
--- a/public/js/netbootxyz-web.js
+++ b/public/js/netbootxyz-web.js
@@ -236,7 +236,7 @@ function revertconfig(filename){
 }
 // Create a new file
 function createipxe(){
-  var filename = $('.ipxefilename').val();
+  var filename = $('.ipxefilename').val().trim();
   if (filename){
   socket.emit('createipxe',filename);
   $('#pagecontent').empty();


### PR DESCRIPTION
When copying an pasting filenames, the whitespace is preserved in the filename but not presented in the UI. Removing the whitespace from the filename upon file creation avoids extensive troubleshooting.