### PR TITLE
Update app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,6 +40,7 @@ baserouter.get("/", function (req, res) {
   res.render(__dirname + '/public/index.ejs', {baseurl: baseurl});
 });
 baserouter.get("/netbootxyz-web.js", function (req, res) {
+  res.setHeader("Content-Type", "application/javascript");
   res.render(__dirname + '/public/netbootxyz-web.ejs', {baseurl: baseurl});
 });
 //// Public JS and CSS ////


### PR DESCRIPTION
Set request header type for servers that enforce strict mime checking (i.e. serving over CloudFlare). Previously mime type defaulted to text/html which would not allow execution.

Fixes #12 

Signed-off-by: Michael Williams <Michael.Williams@glexia.com>