### PR TITLE
Fix ESM parse error for isbinaryfile mock in tests

### DIFF
--- a/tests/unit/app.test.js
+++ b/tests/unit/app.test.js
@@ -10,7 +10,9 @@ jest.mock('child_process');
 jest.mock('systeminformation');
 jest.mock('js-yaml');
 jest.mock('readdirp');
-jest.mock('isbinaryfile');
+jest.mock('isbinaryfile', () => ({
+  isBinaryFile: jest.fn(),
+}));
 
 describe('NetbootXYZ WebApp', () => {
   let app;


### PR DESCRIPTION
## Summary

- `jest.mock('isbinaryfile')` without a factory still attempts to parse the real ESM-only module to auto-generate the mock, causing a `SyntaxError: Cannot use import statement outside a module` failure
- Provide an explicit factory function `() => ({ isBinaryFile: jest.fn() })` so Jest never loads the real module

Follows up on #132 which addressed this for CI but the fix didn't fully prevent the ESM parse on all environments.